### PR TITLE
Upgrade kotlin version to 2.0.20

### DIFF
--- a/wifi_flutter/android/build.gradle
+++ b/wifi_flutter/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.weplenish.wifi_flutter'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.41'
+    ext.kotlin_version = '2.0.20'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
When trying to use wifi_flutter in a project that uses a recent kotlin versions it is needed to upgrade the kotlin version of wifi_flutter.